### PR TITLE
Chore/components

### DIFF
--- a/app/src/main/java/com/app/planify/components/PlBadge.kt
+++ b/app/src/main/java/com/app/planify/components/PlBadge.kt
@@ -1,0 +1,45 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PlBadge(
+    text: String,
+    modifier: Modifier = Modifier,
+    containerColor: Color = PlColors.Primary,
+    contentColor: Color = PlColors.OnPrimary
+) {
+    Box(
+        modifier = modifier
+            .background(containerColor.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .padding(horizontal = PlSpacing.sm, vertical = 3.dp)
+    ) {
+        Text(
+            text = text,
+            style = PlTypography.labelSmall,
+            color = containerColor
+        )
+    }
+}
+
+// Convenience: maps task priority string to the right color
+@Composable
+fun PlPriorityBadge(priority: String, modifier: Modifier = Modifier) {
+    val color = when (priority.lowercase()) {
+        "alta", "high"   -> PlColors.Error
+        "media", "medium" -> Color(0xFFB45309) // amber — no semantic token needed
+        else             -> PlColors.Primary   // baja / low
+    }
+    PlBadge(text = priority, modifier = modifier, containerColor = color)
+}

--- a/app/src/main/java/com/app/planify/components/PlBottomBar.kt
+++ b/app/src/main/java/com/app/planify/components/PlBottomBar.kt
@@ -1,0 +1,84 @@
+package com.app.planify.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Timer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.app.planify.constants.Routes
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlTypography
+
+private data class PlNavItem(
+    val label: String,
+    val route: String,
+    val icon: ImageVector,
+    val selectedIcon: ImageVector
+)
+
+private val navItems = listOf(
+    PlNavItem("Home",     "home",     Icons.Outlined.Home,         Icons.Filled.Home),
+    PlNavItem("Tasks",    "tasks",    Icons.Outlined.CheckCircle,  Icons.Filled.CheckCircle),
+    PlNavItem("Pomodoro", "pomodoro", Icons.Outlined.Timer,        Icons.Filled.Timer),
+    PlNavItem("Profile",  "profile",  Icons.Outlined.Person,       Icons.Filled.Person),
+)
+
+@Composable
+fun PlBottomBar(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+
+    NavigationBar(
+        modifier = modifier,
+        containerColor = PlColors.Surface
+    ) {
+        navItems.forEach { item ->
+            val selected = currentRoute == item.route
+            NavigationBarItem(
+                selected = selected,
+                onClick = {
+                    if (!selected) {
+                        navController.navigate(item.route) {
+                            // Always pop back to Home (without saving state)
+                            // so any tab click clears the stack above Home first
+                            popUpTo(Routes.HOME) { inclusive = false }
+                            launchSingleTop = true
+                        }
+                    }
+                },
+                icon = {
+                    Icon(
+                        imageVector = if (selected) item.selectedIcon else item.icon,
+                        contentDescription = item.label
+                    )
+                },
+                label = { Text(item.label, style = PlTypography.labelSmall) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = PlColors.Primary,
+                    selectedTextColor = PlColors.Primary,
+                    indicatorColor = PlColors.Container,
+                    unselectedIconColor = PlColors.TextHint,
+                    unselectedTextColor = PlColors.TextHint
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlButton.kt
+++ b/app/src/main/java/com/app/planify/components/PlButton.kt
@@ -1,0 +1,36 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PlButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier.fillMaxWidth().height(52.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = PlColors.Primary,
+            contentColor = PlColors.OnPrimary,
+            disabledContainerColor = PlColors.Primary.copy(alpha = 0.4f),
+            disabledContentColor = PlColors.OnPrimary.copy(alpha = 0.6f)
+        )
+    ) {
+        Text(text, style = PlTypography.labelLarge)
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlCard.kt
+++ b/app/src/main/java/com/app/planify/components/PlCard.kt
@@ -1,0 +1,41 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+
+@Composable
+fun PlCard(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    if (onClick != null) {
+        Card(
+            onClick = onClick,
+            modifier = modifier,
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = PlColors.Surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        ) {
+            Column(modifier = Modifier.padding(PlSpacing.md), content = content)
+        }
+    } else {
+        Card(
+            modifier = modifier,
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = PlColors.Surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        ) {
+            Column(modifier = Modifier.padding(PlSpacing.md), content = content)
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlErrorMessage.kt
+++ b/app/src/main/java/com/app/planify/components/PlErrorMessage.kt
@@ -1,0 +1,48 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PlErrorMessage(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.ErrorOutline,
+                contentDescription = null,
+                tint = PlColors.Error
+            )
+            Spacer(modifier = Modifier.height(PlSpacing.sm))
+            Text(
+                text = message,
+                style = PlTypography.bodyMedium,
+                color = PlColors.TextHint,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlFab.kt
+++ b/app/src/main/java/com/app/planify/components/PlFab.kt
@@ -1,0 +1,24 @@
+package com.app.planify.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.app.planify.ui.theme.PlColors
+
+@Composable
+fun PlFab(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = modifier,
+        containerColor = PlColors.Primary,
+        contentColor = PlColors.OnPrimary
+    ) {
+        Icon(imageVector = Icons.Filled.Add, contentDescription = "Add")
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlInput.kt
+++ b/app/src/main/java/com/app/planify/components/PlInput.kt
@@ -1,0 +1,66 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PlInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    error: String? = null,
+    isPassword: Boolean = false
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label, style = PlTypography.bodyMedium) },
+        isError = error != null,
+        supportingText = error?.let { { Text(it, style = PlTypography.labelSmall, color = PlColors.Error) } },
+        visualTransformation = if (isPassword && !passwordVisible) PasswordVisualTransformation() else VisualTransformation.None,
+        trailingIcon = if (isPassword) {
+            {
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(
+                        imageVector = if (passwordVisible) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff,
+                        contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                        tint = PlColors.TextHint
+                    )
+                }
+            }
+        } else null,
+        singleLine = true,
+        shape = RoundedCornerShape(12.dp),
+        modifier = modifier.fillMaxWidth(),
+        textStyle = PlTypography.bodyLarge,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = PlColors.Primary,
+            focusedLabelColor = PlColors.Primary,
+            cursorColor = PlColors.Primary,
+            errorBorderColor = PlColors.Error,
+            errorLabelColor = PlColors.Error
+        )
+    )
+}

--- a/app/src/main/java/com/app/planify/components/PlLoader.kt
+++ b/app/src/main/java/com/app/planify/components/PlLoader.kt
@@ -1,0 +1,19 @@
+package com.app.planify.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.app.planify.ui.theme.PlColors
+
+@Composable
+fun PlLoader(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(color = PlColors.Primary)
+    }
+}

--- a/app/src/main/java/com/app/planify/components/PlTextButton.kt
+++ b/app/src/main/java/com/app/planify/components/PlTextButton.kt
@@ -1,0 +1,23 @@
+package com.app.planify.components
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PlTextButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TextButton(onClick = onClick, modifier = modifier) {
+        Text(
+            text = text,
+            style = PlTypography.bodyMedium,
+            color = PlColors.Primary
+        )
+    }
+}


### PR DESCRIPTION
# chore: add reusable Pl* component library
                                                                               
  ## Summary                                                                 
                                                                               
  - Add the full set of shared composables under `components/` with the `Pl`   
  prefix
  - Every component uses `PlColors`, `PlTypography`, and `PlSpacing` — no      
  hardcoded values                                                             
  - All components expose `modifier: Modifier = Modifier` for layout
  flexibility at call-site                                                     
                                                                             
  ## Components added                                                          
                                                                             
  | Component | Purpose |                                                      
  |---|---|
  | `PlButton` | Primary CTA button |                                          
  | `PlTextButton` | Secondary / ghost button |                              
  | `PlInput` | Text field with label and error state |                        
  | `PlCard` | Surface container for content blocks |
  | `PlBadge` | Status / label chip |                                          
  | `PlLoader` | Full-screen loading indicator |                               
  | `PlErrorMessage` | Inline error display |                                  
  | `PlFab` | Floating action button |                                         
  | `PlBottomBar` | Bottom navigation bar |
                                                 