### PR TITLE
configure navigation structure

### DIFF
--- a/app/src/main/java/com/app/planify/AppNavigation.kt
+++ b/app/src/main/java/com/app/planify/AppNavigation.kt
@@ -1,0 +1,112 @@
+package com.app.planify
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.app.planify.components.PlBottomBar
+import com.app.planify.constants.Routes
+import com.app.planify.screens.auth.AuthScreen
+import com.app.planify.screens.auth.OnboardingScreen
+import com.app.planify.screens.auth.OtpScreen
+import com.app.planify.screens.home.HomeScreen
+import com.app.planify.screens.pomodoro.PomodoroScreen
+import com.app.planify.screens.profile.ProfileScreen
+import com.app.planify.screens.tasks.TasksScreen
+
+@Composable
+fun AppNavigation() {
+    val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+
+    val bottomBarRoutes = setOf(Routes.HOME, Routes.TASKS, Routes.POMODORO, Routes.PROFILE)
+    val showBottomBar = currentRoute in bottomBarRoutes
+
+    Scaffold(
+        bottomBar = {
+            if (showBottomBar) PlBottomBar(navController = navController)
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Routes.AUTH,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+
+            // ── Auth ──────────────────────────────────────────────────────────
+
+            composable(Routes.AUTH) {
+                AuthScreen(
+                    onNavigateToOtp = { email -> navController.navigate(Routes.otp(email)) }
+                )
+            }
+
+            composable(
+                route = Routes.OTP,
+                arguments = listOf(navArgument("email") { type = NavType.StringType })
+            ) { backStack ->
+                val email = android.net.Uri.decode(
+                    backStack.arguments?.getString("email") ?: ""
+                )
+                OtpScreen(
+                    email = email,
+                    onNavigateToOnboarding = {
+                        navController.navigate(Routes.ONBOARDING) {
+                            popUpTo(Routes.AUTH) { inclusive = true }
+                        }
+                    },
+                    onNavigateToHome = {
+                        navController.navigate(Routes.HOME) {
+                            popUpTo(Routes.AUTH) { inclusive = true }
+                        }
+                    },
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+
+            composable(Routes.ONBOARDING) {
+                OnboardingScreen(
+                    onNavigateToHome = {
+                        navController.navigate(Routes.HOME) {
+                            popUpTo(Routes.ONBOARDING) { inclusive = true }
+                        }
+                    },
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+
+            // ── Main app ──────────────────────────────────────────────────────
+
+            composable(Routes.HOME) {
+                HomeScreen(
+                    onNavigateToTasks    = { navController.navigate(Routes.TASKS) },
+                    onNavigateToPomodoro = { navController.navigate(Routes.POMODORO) }
+                )
+            }
+
+            composable(Routes.TASKS) {
+                TasksScreen(
+                    onNavigateToAdd = {
+                        // TODO: navController.navigate(Routes.ADD_TASK)
+                    }
+                )
+            }
+
+            composable(Routes.POMODORO) {
+                PomodoroScreen()
+            }
+
+            composable(Routes.PROFILE) {
+                ProfileScreen()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/MainActivity.kt
+++ b/app/src/main/java/com/app/planify/MainActivity.kt
@@ -4,13 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.app.planify.ui.theme.PlanifyTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +12,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PlanifyTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                AppNavigation()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    PlanifyTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/app/planify/constants/Routes.kt
+++ b/app/src/main/java/com/app/planify/constants/Routes.kt
@@ -1,0 +1,22 @@
+package com.app.planify.constants
+
+object Routes {
+  // Auth flow
+  const val AUTH = "auth"
+  const val OTP = "otp/{email}"
+  const val ONBOARDING = "onboarding"
+
+  // Main app (bottom nav)
+  const val HOME = "home"
+  const val TASKS = "tasks"
+  const val POMODORO = "pomodoro"
+  const val PROFILE = "profile"
+
+  // TODO: uncomment when screens are ready
+  // const val TASK_DETAIL = "tasks/{taskId}"
+  // const val ADD_TASK    = "tasks/add"
+  // fun taskDetail(taskId: Int) = "tasks/$taskId"
+
+  // Builder — email needs encoding because it contains '@'
+  fun otp(email: String) = "otp/${android.net.Uri.encode(email)}"
+}


### PR DESCRIPTION
# Title: feat: add navigation graph and route constants                        
                                                             
  ## Summary

  - Add `Routes` object with all named routes as string constants              
  - Add `AppNavigation` composable wiring the full NavHost with typed
    argument passing between screens                                           
  - Wire `MainActivity` to host `AppNavigation` as the single entry point      
                                                                               
  ## What's included                                                           
                                                                               
  | File | Purpose |
  |---|---|
  | `constants/Routes.kt` | Single source of truth for all route strings |     
  | `AppNavigation.kt` | NavHost with every destination and back-stack logic |
  | `MainActivity.kt` | Updated to host `AppNavigation` |                      
                                                                               
  ## Route map                                                                 
                                                                               
  | Route | Destination |
  |---|---|
  | `auth` | AuthScreen |
  | `otp/{email}` | OtpScreen |                                                
  | `onboarding` | OnboardingScreen |                                          
  | `home` | HomeScreen |                                                      
  | `tasks` | TasksScreen |                                                    
  | `tasks/{taskId}` | TaskDetailScreen |
  | `tasks/add` | AddTaskScreen |                                              
  | `pomodoro` | PomodoroScreen |
  | `profile` | ProfileScreen |                                                
                                                                               
  ## Notes
                                                                               
  - `email` argument in `otp/{email}` is URL-encoded at call-site              
  - `taskId` is typed as `Int` via `navArgument`
  - Start destination is `auth`; post-login redirect lives in `AuthViewModel` 