### PR TITLE
Feat/auth

### DIFF
--- a/app/src/main/java/com/app/planify/screens/auth/AuthScreen.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/AuthScreen.kt
@@ -1,0 +1,115 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.app.planify.components.PlButton
+import com.app.planify.components.PlInput
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun AuthScreen(
+    viewModel: AuthViewModel = viewModel(),
+    onNavigateToOtp: (String) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PlColors.Background)
+            .padding(horizontal = PlSpacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        PlLogo()
+
+        Spacer(Modifier.height(PlSpacing.xl))
+
+        // TODO: implementar Google Sign-In con GoogleSignInClient
+        OutlinedButton(
+            onClick = { /* TODO: Google Sign-In */ },
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(1.dp, PlColors.TextHint)
+        ) {
+            Text("G  ", color = PlColors.Primary, style = PlTypography.titleMedium)
+            Text("Continuar con Google", style = PlTypography.labelLarge)
+        }
+
+        Spacer(Modifier.height(PlSpacing.md))
+        PlDivider()
+        Spacer(Modifier.height(PlSpacing.md))
+
+        PlInput(
+            value = viewModel.email,
+            onValueChange = viewModel::onEmailChange,
+            label = "Correo electrónico"
+        )
+
+        Spacer(Modifier.height(PlSpacing.md))
+
+        PlButton(
+            text = "Continuar",
+            enabled = viewModel.email.isNotBlank(),
+            onClick = { viewModel.continuar(onNavigateToOtp) }
+        )
+
+        Spacer(Modifier.height(PlSpacing.sm))
+
+        Text(
+            text = "Ingresa tu email, detectamos si es cuenta nueva",
+            style = PlTypography.bodyMedium,
+            color = PlColors.TextHint,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun PlLogo() {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .background(PlColors.Primary, CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("P", style = PlTypography.headlineMedium, color = PlColors.OnPrimary)
+    }
+    Spacer(Modifier.height(PlSpacing.md))
+    Text("Planify", style = PlTypography.headlineLarge, color = PlColors.TextMain)
+    Text("tu kit de estudio", style = PlTypography.bodyMedium, color = PlColors.TextHint)
+}
+
+@Composable
+private fun PlDivider() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PlSpacing.sm)
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f), color = PlColors.TextHint.copy(alpha = 0.3f))
+        Text("o", style = PlTypography.bodyMedium, color = PlColors.TextHint)
+        HorizontalDivider(modifier = Modifier.weight(1f), color = PlColors.TextHint.copy(alpha = 0.3f))
+    }
+}

--- a/app/src/main/java/com/app/planify/screens/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/AuthViewModel.kt
@@ -1,0 +1,24 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class AuthViewModel : ViewModel() {
+
+    var email by mutableStateOf("")
+        private set
+
+    fun onEmailChange(value: String) { email = value }
+
+    fun continuar(onNavigate: (String) -> Unit) {
+        viewModelScope.launch {
+            // TODO: POST /auth/v1/otp { email }
+            // TODO: el backend devuelve siempre la misma respuesta (anti-enumeración)
+            onNavigate(email)
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/screens/auth/OnboardingScreen.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/OnboardingScreen.kt
@@ -1,0 +1,79 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBackIosNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.app.planify.components.PlButton
+import com.app.planify.components.PlInput
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun OnboardingScreen(
+    viewModel: OnboardingViewModel = viewModel(),
+    onNavigateToHome: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PlColors.Background)
+            .padding(horizontal = PlSpacing.lg)
+    ) {
+        Spacer(Modifier.height(PlSpacing.lg))
+
+        IconButton(onClick = onNavigateBack) {
+            Icon(Icons.Outlined.ArrowBackIosNew, contentDescription = "Volver", tint = PlColors.TextMain)
+        }
+
+        Spacer(Modifier.height(PlSpacing.lg))
+
+        Text("Completa tu perfil", style = PlTypography.headlineMedium, color = PlColors.TextMain)
+        Spacer(Modifier.height(PlSpacing.xs))
+        Text("Solo la primera vez", style = PlTypography.bodyMedium, color = PlColors.TextHint)
+
+        Spacer(Modifier.height(PlSpacing.xl))
+
+        PlInput(
+            value = viewModel.name,
+            onValueChange = viewModel::onNameChange,
+            label = "Nombre completo"
+        )
+
+        Spacer(Modifier.height(PlSpacing.md))
+
+        PlInput(
+            value = viewModel.career,
+            onValueChange = viewModel::onCareerChange,
+            label = "Carrera (opcional)"
+        )
+
+        Spacer(Modifier.height(PlSpacing.md))
+
+        PlInput(
+            value = viewModel.university,
+            onValueChange = viewModel::onUniversityChange,
+            label = "Universidad (opcional)"
+        )
+
+        Spacer(Modifier.height(PlSpacing.xl))
+
+        PlButton(
+            text = "Empezar",
+            enabled = viewModel.name.isNotBlank(),
+            onClick = { viewModel.complete(onNavigateToHome) }
+        )
+    }
+}

--- a/app/src/main/java/com/app/planify/screens/auth/OnboardingViewModel.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/OnboardingViewModel.kt
@@ -1,0 +1,30 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class OnboardingViewModel : ViewModel() {
+
+    var name by mutableStateOf("")
+        private set
+    var career by mutableStateOf("")
+        private set
+    var university by mutableStateOf("")
+        private set
+
+    fun onNameChange(value: String)       { name = value }
+    fun onCareerChange(value: String)     { career = value }
+    fun onUniversityChange(value: String) { university = value }
+
+    fun complete(onNavigate: () -> Unit) {
+        viewModelScope.launch {
+            // TODO: guardar perfil en Supabase (nombre, carrera, universidad)
+            // TODO: PATCH /rest/v1/profiles { name, career, university }
+            onNavigate()
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/screens/auth/OtpScreen.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/OtpScreen.kt
@@ -1,0 +1,141 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBackIosNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.app.planify.components.PlButton
+import com.app.planify.components.PlTextButton
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun OtpScreen(
+    email: String,
+    viewModel: OtpViewModel = viewModel(),
+    onNavigateToOnboarding: () -> Unit,
+    onNavigateToHome: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PlColors.Background)
+            .padding(horizontal = PlSpacing.lg),
+    ) {
+        Spacer(Modifier.height(PlSpacing.lg))
+
+        IconButton(onClick = onNavigateBack) {
+            Icon(Icons.Outlined.ArrowBackIosNew, contentDescription = "Volver", tint = PlColors.TextMain)
+        }
+
+        Spacer(Modifier.height(PlSpacing.lg))
+
+        Text("Código de verificación", style = PlTypography.headlineMedium, color = PlColors.TextMain)
+        Spacer(Modifier.height(PlSpacing.xs))
+        Text(
+            text = "Enviamos un código a\n$email",
+            style = PlTypography.bodyMedium,
+            color = PlColors.TextHint
+        )
+
+        Spacer(Modifier.height(PlSpacing.xl))
+
+        OtpBoxes(
+            code = viewModel.code,
+            onCodeChange = viewModel::onCodeChange
+        )
+
+        Spacer(Modifier.height(PlSpacing.xl))
+
+        PlButton(
+            text = "Verificar código",
+            enabled = viewModel.code.length == 6,
+            onClick = {
+                viewModel.verify(
+                    email = email,
+                    onNewUser = onNavigateToOnboarding,
+                    onExistingUser = onNavigateToHome
+                )
+            }
+        )
+
+        Spacer(Modifier.height(PlSpacing.md))
+
+        PlTextButton(
+            text = "Reenviar código",
+            onClick = { viewModel.resend(email) },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+
+        Text(
+            text = "válido por 5 minutos",
+            style = PlTypography.labelSmall,
+            color = PlColors.TextHint,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+    }
+}
+
+@Composable
+private fun OtpBoxes(code: String, onCodeChange: (String) -> Unit) {
+    BasicTextField(
+        value = code,
+        onValueChange = onCodeChange,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+        decorationBox = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(PlSpacing.sm)
+            ) {
+                repeat(6) { i ->
+                    val char = code.getOrNull(i)
+                    val isActive = i == code.length
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .border(
+                                width = if (isActive) 2.dp else 1.dp,
+                                color = when {
+                                    isActive   -> PlColors.Primary
+                                    char != null -> PlColors.Primary.copy(alpha = 0.6f)
+                                    else        -> PlColors.TextHint.copy(alpha = 0.4f)
+                                },
+                                shape = RoundedCornerShape(10.dp)
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = char?.toString() ?: "",
+                            style = PlTypography.titleLarge,
+                            color = PlColors.TextMain,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/app/planify/screens/auth/OtpViewModel.kt
+++ b/app/src/main/java/com/app/planify/screens/auth/OtpViewModel.kt
@@ -1,0 +1,34 @@
+package com.app.planify.screens.auth
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class OtpViewModel : ViewModel() {
+
+    var code by mutableStateOf("")
+        private set
+
+    fun onCodeChange(value: String) {
+        if (value.length <= 6 && value.all { it.isDigit() }) code = value
+    }
+
+    fun verify(email: String, onNewUser: () -> Unit, onExistingUser: () -> Unit) {
+        viewModelScope.launch {
+            // TODO: POST /auth/v1/verify { email, token: code, type: "email" }
+            // TODO: response contiene { access_token, isNewUser }
+            // TODO: TokenManager.saveToken(response.accessToken)
+            // TODO: if (response.isNewUser) onNewUser() else onExistingUser()
+            onNewUser() // T1: simula siempre usuario nuevo → va a Onboarding
+        }
+    }
+
+    fun resend(email: String) {
+        viewModelScope.launch {
+            // TODO: POST /auth/v1/otp { email } — reenviar código
+        }
+    }
+}


### PR DESCRIPTION
# feat: auth flow screens and ViewModels                                     
                                                                               
  ## Summary                                                                   
                  
  - Add `AuthScreen` + `AuthViewModel` — email input, OTP send,
  anti-enumeration response handling
  - Add `OtpScreen` + `OtpViewModel` — 6-digit code input and verification
  - Add `OnboardingScreen` + `OnboardingViewModel` — post-registration
  first-time setup                                                             
   
  ## Files                                                                     
                  
  | File | Purpose |
  |---|---|
  | `AuthScreen.kt` | Email input UI, delegates to ViewModel |
  | `AuthViewModel.kt` | Validates email, calls OTP send endpoint |
  | `OtpScreen.kt` | 6-digit code input UI |                                   
  | `OtpViewModel.kt` | Validates code, handles `isNewUser` redirect |
  | `OnboardingScreen.kt` | First-time setup UI |                              
  | `OnboardingViewModel.kt` | Onboarding state and completion logic |         
   