### PR TITLE
feat: add intial structure for tasks screen

### DIFF
--- a/app/src/main/java/com/app/planify/screens/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/app/planify/screens/tasks/TasksScreen.kt
@@ -1,0 +1,119 @@
+package com.app.planify.screens.tasks
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.app.planify.components.PlCard
+import com.app.planify.components.PlErrorMessage
+import com.app.planify.components.PlFab
+import com.app.planify.components.PlLoader
+import com.app.planify.components.PlPriorityBadge
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlSpacing
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun TasksScreen(
+    viewModel: TasksViewModel = viewModel(),
+    onNavigateToAdd: () -> Unit = {}
+) {
+    val state = viewModel.state
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PlColors.Background)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TasksHeader()
+            when (state) {
+                is TasksState.Loading -> PlLoader()
+                is TasksState.Error   -> PlErrorMessage(state.message)
+                is TasksState.Success -> TasksList(tasks = state.tasks)
+            }
+        }
+
+        // TODO: navegar a AddTaskScreen cuando exista
+        PlFab(
+            onClick = onNavigateToAdd,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(PlSpacing.lg)
+        )
+    }
+}
+
+@Composable
+private fun TasksHeader() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PlSpacing.lg, vertical = PlSpacing.md)
+    ) {
+        Text("Mis Tareas", style = PlTypography.headlineMedium, color = PlColors.TextMain)
+        Text("Organiza tu semana", style = PlTypography.bodyMedium, color = PlColors.TextHint)
+    }
+}
+
+@Composable
+private fun TasksList(tasks: List<Task>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(PlSpacing.sm),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+            horizontal = PlSpacing.lg,
+            vertical = PlSpacing.sm
+        )
+    ) {
+        items(tasks) { task ->
+            TaskCard(task = task)
+        }
+        // Spacer para que el FAB no tape la última tarea
+        item { Spacer(Modifier.height(PlSpacing.xl)) }
+    }
+}
+
+@Composable
+private fun TaskCard(task: Task) {
+    PlCard(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = {
+            // TODO: navegar a TaskDetailScreen(task.id)
+        }
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = task.title,
+                    style = PlTypography.titleMedium,
+                    color = PlColors.TextMain
+                )
+                Spacer(Modifier.height(PlSpacing.xs))
+                Text(
+                    text = task.dueDate,
+                    style = PlTypography.labelSmall,
+                    color = PlColors.TextHint
+                )
+            }
+            PlPriorityBadge(priority = task.priority)
+        }
+    }
+}

--- a/app/src/main/java/com/app/planify/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/app/planify/screens/tasks/TasksViewModel.kt
@@ -1,0 +1,51 @@
+package com.app.planify.screens.tasks
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+// TODO: mover a api/models/TaskModels.kt cuando se conecte el backend
+data class Task(
+    val id: Int,
+    val title: String,
+    val dueDate: String,
+    val priority: String,
+    val isDone: Boolean = false
+)
+
+class TasksViewModel : ViewModel() {
+
+    var state by mutableStateOf<TasksState>(TasksState.Loading)
+        private set
+
+    init { loadTasks() }
+
+    fun loadTasks() {
+        viewModelScope.launch {
+            state = TasksState.Loading
+            try {
+                // TODO: reemplazar con TasksRepository.getTasks()
+                // TODO: GET /rest/v1/tasks?user_id=eq.{userId}&select=*
+                val fake = listOf(
+                    Task(1, "Estudiar parcial de cálculo",    "10 May",  "Alta"),
+                    Task(2, "Entregar laboratorio de física", "12 May",  "Media"),
+                    Task(3, "Leer capítulo 4 de historia",   "15 May",  "Baja"),
+                    Task(4, "Preparar exposición grupal",     "18 May",  "Alta"),
+                    Task(5, "Resolver ejercicios de álgebra", "20 May", "Media")
+                )
+                state = TasksState.Success(fake)
+            } catch (e: Exception) {
+                state = TasksState.Error("No se pudieron cargar las tareas")
+            }
+        }
+    }
+}
+
+sealed class TasksState {
+    object Loading                            : TasksState()
+    data class Success(val tasks: List<Task>) : TasksState()
+    data class Error(val message: String)     : TasksState()
+}


### PR DESCRIPTION
  # feat: tasks screen and ViewModel

  ## Summary

  - Add `TasksScreen` + `TasksViewModel` as the main task list view            
   
  ## Files                                                                     
                  
  | File | Purpose |
  |---|---|
  | `TasksScreen.kt` | Task list UI, handles loading/error/success states |
  | `TasksViewModel.kt` | Loads tasks, exposes sealed `TasksUiState` via
  `StateFlow` |         