### PR TITLE
feat: add PomodoroScreen as screen

### DIFF
--- a/app/src/main/java/com/app/planify/screens/pomodoro/PomodoroScreen.kt
+++ b/app/src/main/java/com/app/planify/screens/pomodoro/PomodoroScreen.kt
@@ -1,0 +1,27 @@
+package com.app.planify.screens.pomodoro
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.app.planify.ui.theme.PlColors
+import com.app.planify.ui.theme.PlTypography
+
+@Composable
+fun PomodoroScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PlColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Pomodoro — próximamente",
+            style = PlTypography.bodyMedium,
+            color = PlColors.TextHint
+        )
+    }
+}


### PR DESCRIPTION
  # WIP: Pomodoro screen, UI scaffold                                         
                                                                               
  ## Status                                                                    
                                                                               
  Work in progress — screen structure and layout are defined, timer logic      
  pending.                                                                     
                                                                               
  ## Summary                                                                   
                                                                             
  - Add `PomodoroScreen` with the visual scaffold: timer display, session
  controls and cycle indicators                                                
  - No ViewModel yet; state is static mock data while the timer logic is
  designed                                                                     
                                                                               
  ## Pending before merge
                                                                               
  - [ ] `PomodoroViewModel` with countdown timer using `viewModelScope` +    
  coroutines                                                                   
  - [ ] Work / short break / long break cycle logic
  - [ ] Session persistence (how many pomodoros completed today)               
                                                     